### PR TITLE
Updated for compatibility with TinyTracer v2.3

### DIFF
--- a/TinyProcessor.py
+++ b/TinyProcessor.py
@@ -34,6 +34,8 @@ def process_syscalls(tag_file):
                     winapi = syscall_to_winapi[syscall]
                     lines[i] = lines[i].replace(syscall_pos, winapi)
                     i += 1
+                    if not lines[i].startswith(f"\t"):
+                        i += 1 # skip fuction's name
 
                     # add argument names of function
                     remove = False  # used to handle Nt fxs that are undeclared

--- a/TinyProcessor.py
+++ b/TinyProcessor.py
@@ -28,10 +28,11 @@ def process_syscalls(tag_file):
 
             # replace syscall number w/ function name
             if "SYSCALL" in lines[i]:
-                syscall = int(lines[i].split(":")[1], 16)
+                syscall_pos = lines[i].split(":")[1].split("\n")[0]
+                syscall = int(syscall_pos.split("(")[0], 16)
                 if syscall in syscall_to_winapi:
                     winapi = syscall_to_winapi[syscall]
-                    lines[i] = lines[i].replace(hex(syscall), winapi)
+                    lines[i] = lines[i].replace(syscall_pos, winapi)
                     i += 1
 
                     # add argument names of function


### PR DESCRIPTION
Hi! Starting from the new version, [2.3](https://github.com/hasherezade/tiny_tracer/releases/tag/2.3), Tiny Tracer natively supports resolving syscalls to function names. But I see that your tool can add even more context, which is cool!
I made a quick check, and realized that my update broke compatibility with your tool, so I fixed it. Check it out.
